### PR TITLE
Read debug from launch properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,8 @@ For example:
 Noise noise = OctaveNoise.builder().add(...).build();
 noise = noise.normalize();
 ```
+
+### Debugging
+To view the output that Noise Composer is producing, you can add `-Dnoisecomposer.debug=true` to your program launch arguments.
+This will put the compiled class files that the noise compiler creates in a folder called `noisecomposer` in your root directory.
+This can be useful if you're wanting to see how the compiled bytecode looks under the hood.

--- a/src/main/java/dev/gegy/noise/compile/NoiseCompiler.java
+++ b/src/main/java/dev/gegy/noise/compile/NoiseCompiler.java
@@ -17,8 +17,8 @@ import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public final class NoiseCompiler {
-    private static final boolean DEBUG = false;
-    private static final Path DEBUG_ROOT = Paths.get("debug");
+    private static final boolean DEBUG = System.getProperty("noisecomposer.debug", "false").equals("true");
+    private static final Path DEBUG_ROOT = Paths.get("noisecomposer");
 
     private static final AtomicInteger COUNTER = new AtomicInteger(0);
 


### PR DESCRIPTION
This PR allows the toggling of debug class dumping from launch args, and adds a few lines to the readme stating how to use it. It also changes the debug dump folder from `debug` to `noisecomposer`.